### PR TITLE
chore: added install target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,3 +40,5 @@ target_link_libraries(${PROJECT_NAME}
         ${GSTREAMER_WEBRTC_LDFLAGS}
         ${GSTREAMER_SDP_LDFLAGS}
         ${SOUP_LDFLAGS})
+
+install(TARGETS whpp-play DESTINATION bin)


### PR DESCRIPTION
For homebrew formulae we need to have an install target